### PR TITLE
Race condition fix

### DIFF
--- a/RBQFetchedResultsController.podspec
+++ b/RBQFetchedResultsController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RBQFetchedResultsController"
-  s.version      = "5.0.3"
+  s.version      = "5.0.4"
   s.summary      = "Drop-in replacement for NSFetchedResultsController backed by Realm."
   s.description  = <<-DESC
                     The RBQFetchedResultsController (FRC) is a replacement for NSFetchedResultsController when used in conjunction with RBQRealmNotificationManager and RBQRealmChangeLogger. The controller and delegate follow the same paradigm as NSFetchedResultsController, and allow the developer to monitor changes of an RLMObject subclass.

--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
@@ -821,7 +821,11 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
                     dispatch_semaphore_signal(sem);
                 }
             }];
-            
+			
+			// Wait for notifying that controller has started change its content.
+			// NSInternalInconsistencyException was throws when beginUpdates was called after changes on observed fetchedObjects.
+			// See https://freshbooks.atlassian.net/browse/HEL-12
+			// Added by Smetankin Dmitry
             if (useSem) {
                 dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
             }

--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
@@ -374,7 +374,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         _sectionNameKeyPath = sectionNameKeyPath;
         
 #ifdef DEBUG
-        _logging = true;
+		_logging = true;
 #endif
     }
     
@@ -834,14 +834,14 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
                                                                      sectionChanges:sectionChanges
                                                                               state:state];
 
-        if(self.logging) {
-            NSLog(@"%lu Derived Inserted Sections",(unsigned long)derivedChanges.insertedSectionChanges.count);
-            NSLog(@"%lu Derived Deleted Sections",(unsigned long)derivedChanges.deletedSectionChanges.count);
-            NSLog(@"%lu Derived Added Objects",(unsigned long)derivedChanges.insertedObjectChanges.count);
-            NSLog(@"%lu Derived Deleted Objects",(unsigned long)derivedChanges.deletedObjectChanges.count);
-            NSLog(@"%lu Derived Moved Objects",(unsigned long)derivedChanges.movedObjectChanges.count);
-        }
-        
+		if(self.logging) {
+			NSLog(@"%lu Derived Inserted Sections",(unsigned long)derivedChanges.insertedSectionChanges.count);
+			NSLog(@"%lu Derived Deleted Sections",(unsigned long)derivedChanges.deletedSectionChanges.count);
+			NSLog(@"%lu Derived Added Objects",(unsigned long)derivedChanges.insertedObjectChanges.count);
+			NSLog(@"%lu Derived Deleted Objects",(unsigned long)derivedChanges.deletedObjectChanges.count);
+			NSLog(@"%lu Derived Moved Objects",(unsigned long)derivedChanges.movedObjectChanges.count);
+		}
+		
         // Apply Derived Changes To Cache
         [self applyDerivedChangesToCache:derivedChanges
                                    state:state];

--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
@@ -372,7 +372,7 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         _cacheName = name;
         _fetchRequest = fetchRequest;
         _sectionNameKeyPath = sectionNameKeyPath;
-        
+		
 #ifdef DEBUG
 		_logging = true;
 #endif

--- a/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
+++ b/RBQFetchedResultsController/Source/RBQFetchedResultsController.m
@@ -372,9 +372,9 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
         _cacheName = name;
         _fetchRequest = fetchRequest;
         _sectionNameKeyPath = sectionNameKeyPath;
-		
+        
 #ifdef DEBUG
-		_logging = true;
+        _logging = true;
 #endif
     }
     
@@ -817,7 +817,14 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
 
             [self runOnMainThread:^(){
                 [weakSelf.delegate controllerWillChangeContent:weakSelf];
+                if (useSem) {
+                    dispatch_semaphore_signal(sem);
+                }
             }];
+            
+            if (useSem) {
+                dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+            }
         }
 
         [state.cacheRealm beginWriteTransaction];
@@ -827,14 +834,14 @@ static void * RBQArrayFetchRequestContext = &RBQArrayFetchRequestContext;
                                                                      sectionChanges:sectionChanges
                                                                               state:state];
 
-		if(self.logging) {
-			NSLog(@"%lu Derived Inserted Sections",(unsigned long)derivedChanges.insertedSectionChanges.count);
-			NSLog(@"%lu Derived Deleted Sections",(unsigned long)derivedChanges.deletedSectionChanges.count);
-			NSLog(@"%lu Derived Added Objects",(unsigned long)derivedChanges.insertedObjectChanges.count);
-			NSLog(@"%lu Derived Deleted Objects",(unsigned long)derivedChanges.deletedObjectChanges.count);
-			NSLog(@"%lu Derived Moved Objects",(unsigned long)derivedChanges.movedObjectChanges.count);
-		}
-		
+        if(self.logging) {
+            NSLog(@"%lu Derived Inserted Sections",(unsigned long)derivedChanges.insertedSectionChanges.count);
+            NSLog(@"%lu Derived Deleted Sections",(unsigned long)derivedChanges.deletedSectionChanges.count);
+            NSLog(@"%lu Derived Added Objects",(unsigned long)derivedChanges.insertedObjectChanges.count);
+            NSLog(@"%lu Derived Deleted Objects",(unsigned long)derivedChanges.deletedObjectChanges.count);
+            NSLog(@"%lu Derived Moved Objects",(unsigned long)derivedChanges.movedObjectChanges.count);
+        }
+        
         // Apply Derived Changes To Cache
         [self applyDerivedChangesToCache:derivedChanges
                                    state:state];

--- a/SwiftFetchedResultsController.podspec
+++ b/SwiftFetchedResultsController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftFetchedResultsController"
-  s.version      = "5.0.3"
+  s.version      = "5.0.4"
   s.summary      = "Swift drop-in replacement for NSFetchedResultsController backed by Realm"
   s.description  = <<-DESC
                     The FetchedResultsController (FRC) is a Swift replacement for NSFetchedResultsController when used in conjunction with the ChangeLogger class. The controller and delegate follow the same paradigm as NSFetchedResultsController, and allow the developer to monitor changes of a Realm Swift Object subclass.


### PR DESCRIPTION
## Overview
If a user rotates the device while creating an entity, the app will crash after the entity is saved. This appears to only affect entities with split views, as it is not reproducible with the current implementation of invoices, for example.

Steps:
1. Tap "New".
2. Rotate the device.
3. Enter valid values into all mandatory fields, then tap "Save".

See [TICKET](https://freshbooks.atlassian.net/browse/HEL-12)

#### Notes for Devs
Starting with v4.0 and Realm v0.99, RBQFetchedResultsController works automatically with Realm's fine-grained notification support. It is recommended to use Realm's API directly instead of RBQFetchedResultsController **unless you need support for sections.**

We could add to backlog task to get rid of RBQFetchedResultsController and use Realm's API directly since we don't use sections here.

[Branch](https://github.com/freshbooks/helios/tree/HEL-12-save-entity-on-rotating) with this fix for testing.

[Build](https://dashboard.buddybuild.com/apps/5a0b5f6c4f46da0001afa890/build/5aa27cd3a54226000170f8d3) with this fix on buddybuild. 

#### Checklist:
- [ ] I have added/updated unit tests to cover my business logic changes where possible.
- [ ] I have added/updated snapshot tests for UI changes where possible.
- [x] I have linted my changes.
- [ ] I have checked the code coverage of my changed code.