### PR TITLE
Fixed Internal inconsistency exception

### DIFF
--- a/RBQFetchedResultsController.podspec
+++ b/RBQFetchedResultsController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RBQFetchedResultsController"
-  s.version      = "5.0.4"
+  s.version      = "5.0.5"
   s.summary      = "Drop-in replacement for NSFetchedResultsController backed by Realm."
   s.description  = <<-DESC
                     The RBQFetchedResultsController (FRC) is a replacement for NSFetchedResultsController when used in conjunction with RBQRealmNotificationManager and RBQRealmChangeLogger. The controller and delegate follow the same paradigm as NSFetchedResultsController, and allow the developer to monitor changes of an RLMObject subclass.

--- a/SwiftFetchedResultsController.podspec
+++ b/SwiftFetchedResultsController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftFetchedResultsController"
-  s.version      = "5.0.4"
+  s.version      = "5.0.5"
   s.summary      = "Swift drop-in replacement for NSFetchedResultsController backed by Realm"
   s.description  = <<-DESC
                     The FetchedResultsController (FRC) is a Swift replacement for NSFetchedResultsController when used in conjunction with the ChangeLogger class. The controller and delegate follow the same paradigm as NSFetchedResultsController, and allow the developer to monitor changes of a Realm Swift Object subclass.


### PR DESCRIPTION
## Overview
Currently, iPad has a crash on deletion of an entity after screen rotation.

Steps:
1. Login to the app and open any entity list (e.g. invoices)
2. Open edit screen of any entity
3. Rotate the device by 90 deg.
4. Tap delete entity and confirm the deletion

AR: App crashes
ER: List is shown, entity is deleted

See [HEL-293](https://freshbooks.atlassian.net/browse/HEL-293)

#### Acceptance Criteria
No crash after deleting an entity when a screen was rotated.

#### Notes for Devs
When a screen is rotated, `numberOfRows(in section:)` is called to layout tableView. If we in the deletion flow, there can be a case when:
1) We call `tableView.beginUpdates()`
2) Than RBQ will calculate changes and derive them to cache (numberOfRows(in section:) calls `cache.sections[index].objects.count`)
3) System calls `numberOfRows(in section:)` because the screen was rotated, and this info needs to layout tableView. If collection changes was delivered to cache, method `numberOfRows(in section:)` returns rows count AFTER the deletion was happened (actual count)
4) Delegate method calls `tableView.deleteRow(at indexPath:)`, then delegate calls `tableView.endUpdates()` and here occurs crash with `NSInternalInconsistencyException`reason: 

'Invalid update: invalid number of rows in section 0.  The number of rows contained in an existing section after the update (4) must be equal to the number of rows contained in that section before the update (4), plus or minus the number of rows inserted or deleted from that section (0 inserted, 1 deleted) and plus or minus the number of rows moved into or out of that section (0 moved in, 0 moved out).'

This happens because the system already knows an actual number of rows before `tableView.deleteRow(at indexPath:)` was called, and this number didn't changed after `endUpdates` method. So I've added a semaphores to derive changes to the cache after delegate method was called (Before this changes delegate method could be called later in time after derived changes was already calculated). In this case `numberOfRows(in section:)` will return old rows count, then delegate calls `deleteRow(at indexPath:)` and we derive this changes to the cache, and after `endUpdates` rows count are changed.

We already had a similar problem with RBQ (crash on creating an entity after screen rotates) and fixed it by adding a semaphore to the `beginUpdates` method, but looks like it doesn't fix all raise conditions. 